### PR TITLE
fix for gradle 7 (last flutter version default)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,26 +4,26 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
     }
 }
 
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
 apply plugin: 'com.android.library'
 
 dependencies {
-    compile fileTree(include: '*.jar', dir: 'libs')
-    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation fileTree(include: '*.jar', dir: 'libs')
+    implementation 'androidx.annotation:annotation:1.6.0'
 }
 
 android {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip


### PR DESCRIPTION
The `repositories.jcenter` closed : https://blog.gradle.org/jcenter-shutdown
The `dependencies.compile`  removed on gradle7  https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal